### PR TITLE
changed the scritp's logic, so that it works more reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ Define step classes (by default the step class name is *data-ssn-class*-step-*st
 
 ## To do
 
-The script is quite crude and I want to rebuild it & make it easier to configure soon™ 
+1. The script is quite crude and I want to rebuild it & make it easier to configure soon™
+2. Change the script so that the element starts being tracked when it enters the viewport, but is tracked even if it leaves it (the script looses track when user scrolls too fast)
+3. Refactor

--- a/src/ScrollStepClass.js
+++ b/src/ScrollStepClass.js
@@ -46,8 +46,15 @@
             if(this.inViewport) {
                 this.calcScrollDiference(newScrollValue);
                 this.calcCurrentStepValue();
-                this.validateStep();
+                
+                if(this.scrollDifference > 0 && this.currentStep < this.steps) {
+                    this.moveForward();
+                }
+                else if(this.scrollDifference < 0 && this.currentStep > 0) {
+                    this.moveBackwards();
+                }
             }
+            // console.log('%ccurretStepValue: ' + this.currentStepValue, 'color: #ff0');
         }
 
         calcScrollDiference(newScrollValue) {
@@ -56,38 +63,36 @@
         }
 
         calcCurrentStepValue() {
-            this.currentStepValue += Math.abs(this.scrollDifference);
-        }
-
-        validateStep() {
-            if(this.currentStepValue >= this.stepThreshold) {
-                if(this.scrollDifference > 0 && this.currentStep < this.steps) {
-                    this.moveForward();
-                }
-                else if(this.scrollDifference < 0 && this.currentStep > 0) {
-                    this.moveBackwards();
-                }
-            }
+            this.currentStepValue += this.scrollDifference;
         }
 
         moveForward() {
             let lastStep = this.currentStep;
             let mod = this.currentStepValue % this.stepThreshold;
-            let stepsToTake = (this.currentStepValue - mod) / this.stepThreshold;
-            this.currentStep = Math.min((this.currentStep + stepsToTake), this.steps);
-            this.node.classList.add(this.stepClass + this.settings.stepSuffix + this.currentStep);
-            this.node.classList.remove(this.stepClass + this.settings.stepSuffix + lastStep);
-            this.currentStepValue = mod;
+            let calculatedStep = (this.currentStepValue - mod) / this.stepThreshold;
+            this.currentStep = Math.min(calculatedStep, this.steps);
+            if(this.currentStep > lastStep) {
+                this.node.classList.add(this.stepClass + this.settings.stepSuffix + this.currentStep);
+                this.node.classList.remove(this.stepClass + this.settings.stepSuffix + lastStep);
+            }
         }
 
         moveBackwards() {
             let lastStep = this.currentStep;
-            let mod = this.currentStepValue % this.stepThreshold;
-            let stepsToTake = (this.currentStepValue - mod) / this.stepThreshold;
-            this.currentStep = Math.max(this.currentStep - stepsToTake, 1);
-            this.node.classList.add(this.stepClass + this.settings.stepSuffix + this.currentStep);
-            this.node.classList.remove(this.stepClass + this.settings.stepSuffix + lastStep);
-            this.currentStepValue = mod;
+            let absCurrentStepValue = Math.abs(this.currentStepValue);
+            if(absCurrentStepValue < this.stepThreshold) {
+                this.currentStep = 0;
+                this.node.classList.remove(this.stepClass + this.settings.stepSuffix + lastStep);
+            }
+            else {
+                let mod = absCurrentStepValue % this.stepThreshold;
+                let calculatedStep = (absCurrentStepValue - mod) / this.stepThreshold;
+                this.currentStep = Math.max(calculatedStep, 1);
+                if(this.currentStep < lastStep){
+                    this.node.classList.add(this.stepClass + this.settings.stepSuffix + this.currentStep);
+                    this.node.classList.remove(this.stepClass + this.settings.stepSuffix + lastStep);
+                } 
+            }
         }
     }
 


### PR DESCRIPTION
Now the current scroll value is counted as a whole, opposed to resetting with each step, as it was done before, so the script follows the scroll event more reliably, there is still a problem with leaving the viewport early (scrolling too fast) though.